### PR TITLE
Stringify build system names to match multi-word language names.

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
             var cmd = null;
             var foundLanguage = false;
             builders.forEach(function (el) {
-                if (el.name.toLowerCase() === curOpenLang.toLowerCase()) {
+                if (JSON.stringify(el.name).toLowerCase() === curOpenLang.toLowerCase()) {
                     foundLanguage = true;
                     cmd = el[action];
                 }


### PR DESCRIPTION
If the value of `curOpenLang` is a language name containing more
than one word (for example, "Common Lisp"), a correctly configured
build system name will not match in the comparison
`el.name.toLowerCase() === curOpenLang.toLowerCase()`.
In this case the "No run configuration for current file type" dialog
is displayed even when the build system is configured correctly.

`JSON.stringify()` build system names to ensure that they match.
